### PR TITLE
feat!: require Laravel 13 and PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,7 @@ Install with composer:
  $ composer require salibhdr/typhoon-iran-cities
 ```
 
-For Laravel < 5.5 Register the Service provider in your config/app.php configuration file:
-
-```
-'providers' => [
-
-     # Other service providers...
-     
-     SaliBhdr\TyphoonIranCities\IranCitiesServiceProvider::class,
-],
-```
+Requires Laravel 13 and PHP 8.3 or higher (including PHP 8.5).
 
 ## Getting started
 
@@ -600,8 +591,8 @@ Reference
 
 Based on [ahmadazizi/iran-cities][link-reference-repo] git repository version 3. Take a look For more info.
 
-[ico-laravel]: https://img.shields.io/badge/Laravel-≥5.0-ff2d20?style=flat-square&logo=laravel
-[ico-php]: https://img.shields.io/badge/php-≥5.6-8892bf?style=flat-square&logo=php
+[ico-laravel]: https://img.shields.io/badge/Laravel-^13.0-ff2d20?style=flat-square&logo=laravel
+[ico-php]: https://img.shields.io/badge/php-^8.3-8892bf?style=flat-square&logo=php
 [ico-downloads]: https://poser.pugx.org/salibhdr/typhoon-iran-cities/downloads
 [ico-today-downloads]: https://img.shields.io/packagist/dd/salibhdr/typhoon-iran-cities.svg?style=flat-square
 [ico-license]: https://poser.pugx.org/salibhdr/typhoon-iran-cities/v/unstable

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,11 @@
         }
     },
     "require": {
-        "php": ">=5.6.0",
-        "laravel/framework": ">=5.0"
+        "php": "^8.3",
+        "illuminate/console": "^13.0",
+        "illuminate/database": "^13.0",
+        "illuminate/filesystem": "^13.0",
+        "illuminate/support": "^13.0"
     },
     "minimum-stability": "stable",
     "prefer-stable": true

--- a/src/Commands/Init.php
+++ b/src/Commands/Init.php
@@ -11,7 +11,7 @@ class Init extends AbstractCommand
      * The name and signature of the console command.
      * @var string
      */
-    protected $name = 'iran:init';
+    protected $signature = 'iran:init';
 
     /**
      * The console command description.

--- a/src/Commands/PublishMigrations.php
+++ b/src/Commands/PublishMigrations.php
@@ -12,7 +12,7 @@ class PublishMigrations extends AbstractPublish
      * The name and signature of the console command.
      * @var string
      */
-    protected $name = 'iran:publish:migrations';
+    protected $signature = 'iran:publish:migrations';
 
     /**
      * The console command description.

--- a/src/Commands/PublishModels.php
+++ b/src/Commands/PublishModels.php
@@ -10,7 +10,7 @@ class PublishModels extends AbstractPublish
      * The name and signature of the console command.
      * @var string
      */
-    protected $name = 'iran:publish:models';
+    protected $signature = 'iran:publish:models';
 
     /**
      * The console command description.

--- a/src/IranCitiesServiceProvider.php
+++ b/src/IranCitiesServiceProvider.php
@@ -13,13 +13,15 @@ class IranCitiesServiceProvider extends ServiceProvider
     /**
      * Register the service provider.
      */
-    public function register()
+    public function register(): void
     {
-        $this->commands([
-            Init::class,
-            PublishMigrations::class,
-            PublishModels::class,
-            Import::class,
-        ]);
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                Init::class,
+                PublishMigrations::class,
+                PublishModels::class,
+                Import::class,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
- Bump composer constraints to PHP ^8.3 and Illuminate ^13.0 packages
- Replace deprecated command $name with $signature on artisan commands
- Register console commands only when runningInConsole()
- Update README requirements and badges; drop legacy provider registration docs