### PR TITLE
refactor(commands): use Laravel Signature attributes and traits

### DIFF
--- a/src/Commands/Import.php
+++ b/src/Commands/Import.php
@@ -3,27 +3,21 @@
 namespace SaliBhdr\TyphoonIranCities\Commands;
 
 use Closure;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
 use SaliBhdr\TyphoonIranCities\Enums\RegionTypeEnum;
 use SaliBhdr\TyphoonIranCities\Enums\TargetTypeEnum;
-use Symfony\Component\Console\Input\InputOption;
-use SaliBhdr\TyphoonIranCities\Commands\Abstracts\AbstractCommand;
 
-class Import extends AbstractCommand
+#[Signature('iran:import
+    {--unite : Unite will put all regions into one region table and will not separate regional tables}
+    {--target=all : Target region that you want to import, options : [all, provinces, counties, sectors, cities, city_districts, rural_districts, villages]}
+    {--with-city-coordinates : Import city coordinates (lat/lon) when cities are included in the target}')]
+#[Description('Imports all regions into the database (Can be selected by option)')]
+class Import extends Command
 {
-    /**
-     * The name and signature of the console command.
-     * @var string
-     */
-    protected $signature = 'iran:import';
-
-    /**
-     * The console command description.
-     * @var string
-     */
-    protected $description = 'Imports all regions into the database (Can be selected by option)';
-
     /**
      * @var array
      */
@@ -37,17 +31,6 @@ class Import extends AbstractCommand
         'rural_districts' => TargetTypeEnum::RURAL_DISTRICTS,
         'villages'        => TargetTypeEnum::VILLAGES
     ];
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->getDefinition()->addOptions([
-            new InputOption('unite', null, InputOption::VALUE_NONE, 'Unite will put all regions into one region table and will not separate regional tables'),
-            new InputOption('target', null, InputOption::VALUE_OPTIONAL, 'Target region that you want to import, options : [all, provinces, counties, sectors, cities, city_districts, rural_districts, villages]', 'all'),
-            new InputOption('with-city-coordinates', null, InputOption::VALUE_NONE, 'Import city coordinates (lat/lon) when cities are included in the target'),
-        ]);
-    }
 
     /**
      * Execute the console command.

--- a/src/Commands/Init.php
+++ b/src/Commands/Init.php
@@ -2,34 +2,20 @@
 
 namespace SaliBhdr\TyphoonIranCities\Commands;
 
-use Symfony\Component\Console\Input\InputOption;
-use SaliBhdr\TyphoonIranCities\Commands\Abstracts\AbstractCommand;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use SaliBhdr\TyphoonIranCities\Commands\Traits\AsksBoolQuestions;
 
-class Init extends AbstractCommand
+#[Signature('iran:init
+    {--force : Force to overwrite copied files}
+    {--unite : Unite will put all regions into one region table and will not separate regional tables}
+    {--target=all : Target region that you desire to have, options : [all, provinces, counties, sectors, cities, city_districts, rural_districts, villages]}
+    {--with-city-coordinates : Publish city coordinates migration and import lat/lon when cities are included in the target}')]
+#[Description('Copies models and migrations then imports data')]
+class Init extends Command
 {
-    /**
-     * The name and signature of the console command.
-     * @var string
-     */
-    protected $signature = 'iran:init';
-
-    /**
-     * The console command description.
-     * @var string
-     */
-    protected $description = 'Copies models and migrations then imports data';
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->getDefinition()->addOptions([
-            new InputOption('force', null, InputOption::VALUE_NONE, 'Force to overwrite copied files'),
-            new InputOption('unite', null, InputOption::VALUE_NONE, 'Unite will put all regions into one region table and will not separate regional tables'),
-            new InputOption('target', null, InputOption::VALUE_OPTIONAL, 'Target region that you desire to have, options : [all, provinces, counties, sectors, cities, city_districts, rural_districts, villages]', 'all'),
-            new InputOption('with-city-coordinates', null, InputOption::VALUE_NONE, 'Publish city coordinates migration and import lat/lon when cities are included in the target'),
-        ]);
-    }
+    use AsksBoolQuestions;
 
     public function handle()
     {

--- a/src/Commands/PublishMigrations.php
+++ b/src/Commands/PublishMigrations.php
@@ -2,23 +2,18 @@
 
 namespace SaliBhdr\TyphoonIranCities\Commands;
 
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Filesystem\Filesystem;
-use SaliBhdr\TyphoonIranCities\Commands\Abstracts\AbstractPublish;
+use SaliBhdr\TyphoonIranCities\Commands\Traits\PublishesIranCities;
 
-class PublishMigrations extends AbstractPublish
+#[Signature('iran:publish:migrations' . PublishMigrations::SIGNATURE_OPTIONS)]
+#[Description('Copies migrations into migrations directory')]
+class PublishMigrations extends Command
 {
-    /**
-     * The name and signature of the console command.
-     * @var string
-     */
-    protected $signature = 'iran:publish:migrations';
-
-    /**
-     * The console command description.
-     * @var string
-     */
-    protected $description = 'Copies migrations into migrations directory';
+    use PublishesIranCities;
 
     /**
      * @param array[int] $targets

--- a/src/Commands/PublishModels.php
+++ b/src/Commands/PublishModels.php
@@ -2,21 +2,16 @@
 
 namespace SaliBhdr\TyphoonIranCities\Commands;
 
-use SaliBhdr\TyphoonIranCities\Commands\Abstracts\AbstractPublish;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use SaliBhdr\TyphoonIranCities\Commands\Traits\PublishesIranCities;
 
-class PublishModels extends AbstractPublish
+#[Signature('iran:publish:models' . PublishModels::SIGNATURE_OPTIONS)]
+#[Description('Copies related models')]
+class PublishModels extends Command
 {
-    /**
-     * The name and signature of the console command.
-     * @var string
-     */
-    protected $signature = 'iran:publish:models';
-
-    /**
-     * The console command description.
-     * @var string
-     */
-    protected $description = 'Copies related models';
+    use PublishesIranCities;
 
     /**
      * @param array[int] $targets

--- a/src/Commands/Traits/AsksBoolQuestions.php
+++ b/src/Commands/Traits/AsksBoolQuestions.php
@@ -1,10 +1,8 @@
 <?php
 
-namespace SaliBhdr\TyphoonIranCities\Commands\Abstracts;
+namespace SaliBhdr\TyphoonIranCities\Commands\Traits;
 
-use Illuminate\Console\Command;
-
-abstract class AbstractCommand extends Command
+trait AsksBoolQuestions
 {
     /**
      * @param string $question
@@ -26,5 +24,4 @@ abstract class AbstractCommand extends Command
 
         return $this->askBoolQuestion($question);
     }
-
 }

--- a/src/Commands/Traits/PublishesIranCities.php
+++ b/src/Commands/Traits/PublishesIranCities.php
@@ -1,22 +1,16 @@
 <?php
 
-namespace SaliBhdr\TyphoonIranCities\Commands\Abstracts;
+namespace SaliBhdr\TyphoonIranCities\Commands\Traits;
 
-use Symfony\Component\Console\Input\InputOption;
-
-abstract class AbstractPublish extends AbstractCommand
+trait PublishesIranCities
 {
-    public function __construct()
-    {
-        parent::__construct();
+    use AsksBoolQuestions;
 
-        $this->getDefinition()->addOptions([
-            new InputOption('force', null, InputOption::VALUE_NONE, 'Force to overwrite copied files'),
-            new InputOption('unite', null, InputOption::VALUE_NONE, 'Unite will put all regions into one region table and will not separate regional tables'),
-            new InputOption('target', null, InputOption::VALUE_OPTIONAL, 'Target region that you desire to have, options : [all, provinces, counties, sectors, cities, city_districts, rural_districts, villages]', 'all'),
-            new InputOption('with-city-coordinates', null, InputOption::VALUE_NONE, 'Publish city coordinates migration (lat/lon) when cities are included in the target'),
-        ]);
-    }
+    public const SIGNATURE_OPTIONS = '
+    {--force : Force to overwrite copied files}
+    {--unite : Unite will put all regions into one region table and will not separate regional tables}
+    {--target=all : Target region that you desire to have, options : [all, provinces, counties, sectors, cities, city_districts, rural_districts, villages]}
+    {--with-city-coordinates : Publish city coordinates migration (lat/lon) when cities are included in the target}';
 
     /**
      * @throws \Exception


### PR DESCRIPTION
- Replace AbstractCommand and AbstractPublish base classes with reusable traits
- Declare command signatures and options via #[Signature] and #[Description] attributes
- Remove constructor-based InputOption registration for cleaner Laravel 11+ style